### PR TITLE
apostrophes, "in retrospect"

### DIFF
--- a/_posts/2020-02-14-why-rust-is-loved.adoc
+++ b/_posts/2020-02-14-why-rust-is-loved.adoc
@@ -33,7 +33,7 @@ This probably was much less obvious in the 90s, when today's mainstream language
 _Second_, it does not try to maintain source/semantic compatibility with any existing language.
 Even if we think that const by default is a good idea, we can't employ it in TypeScript, because it needs to stay compatible with JavaScript.
 
-_Third_, (and this is a pure speculation on my part) I feel that the initial bunch of people who designed the language and it's designed principles just had an excellent taste!
+_Third_, (and this is a pure speculation on my part) I feel that the initial bunch of people who designed the language and its designed principles just had an excellent taste!
 
 So, to the list of adorable things!
 
@@ -267,10 +267,10 @@ struct Point {
 
 == Strings
 
-This is again an obvious in retrospective thing.
+Another obvious in retrospect thing.
 
 Strings are represented as utf-8 byte buffers.
-The encoding is fixed, can't be changed, and it's validity is enforced.
+The encoding is fixed, can't be changed, and its validity is enforced.
 There's no random access to "characters", but you can slice string with a byte index, provided that it doesn't fall in the middle of a multi-byte character.
 
 == assert!


### PR DESCRIPTION
> it's designed principles
> it's validity is enforced.

These aren't a contraction of "it is" or "it has", so no apostrophe.

The phrase is "obvious in retrospect", I also tweaked it to be, arguably, more idiomatic.