### PR TITLE
Update 2020-04-13-simple-but-powerful-pratt-parsing.adoc

### DIFF
--- a/_posts/2020-04-13-simple-but-powerful-pratt-parsing.adoc
+++ b/_posts/2020-04-13-simple-but-powerful-pratt-parsing.adoc
@@ -477,7 +477,7 @@ They are tricky, but, if you understand them, everything else is straightforward
 
 == Bells and Whistles
 
-No let's add all kinds of weird expressions to show the power and flexibility of the algorithm.
+Now let's add all kinds of weird expressions to show the power and flexibility of the algorithm.
 First, let's add a high-priority, right associative function composition operator: `.`:
 
 [source,rust,highlight=5]
@@ -962,7 +962,7 @@ This can be parsed as
 or  as
 [source,rust]
 ----
-(a ?: c) ?: e
+a ?: (c ?: e)
 ----
 What is more useful?
 For `?`-chains like this:


### PR DESCRIPTION
Great post, possibly one of the best posts about pratt parsing I've read. While reading I found a typo and you forgot to edit the positions of the parentheses when comparing the possible parse options for the ternary operator.