### PR TITLE
two small typos

### DIFF
--- a/_posts/2020-10-15-study-of-std-io-error.adoc
+++ b/_posts/2020-10-15-study-of-std-io-error.adoc
@@ -306,7 +306,7 @@ where
   T: DeserializeOwned,
 ----
 
-`Read` can fail with `io::Error`, so `serde_json::Error` needs to be able ot represent `io::Error` internally.
+`Read` can fail with `io::Error`, so `serde_json::Error` needs to be able to represent `io::Error` internally.
 I think this is backwards (but I don't know the whole context, I'd be delighted to be proven wrong!), and the signature should have been this instead:
 
 [source,rust]
@@ -342,7 +342,7 @@ A similarly-shaped problem is that `io::Error` doesn't carry a backtrace.
 
 The other problem is that `std::io::Error` is not as efficient as it could be:
 
-* It's size is pretty big:
+* Its size is pretty big:
 +
 [source,rust]
 ----


### PR DESCRIPTION
`it's -> its` and `ot -> to`