### PR TITLE
Fix missing fonts

### DIFF
--- a/css/adoc.css
+++ b/css/adoc.css
@@ -73,8 +73,11 @@ hr {
     margin-bottom: 1em;
 }
 
-code, .listingblock>.content>pre:not(.highlight) {
+code,
+pre {
     font-family: "JetBrains Mono", monospace;
+}
+code, .listingblock>.content>pre:not(.highlight) {
     font-variant-ligatures: none;
     color: rgba(0, 0, 0, .9);
     font-size: 0.75em;

--- a/css/main.css
+++ b/css/main.css
@@ -6,7 +6,6 @@ pre.rouge .hll * {
 }
 
 .site-header a {
-    font-family: "Noto Serif", "DejaVu Serif", serif;
     font-style: normal;
     color: rgba(0, 0, 0, .8);
     text-decoration: none;
@@ -24,7 +23,6 @@ pre.rouge .hll * {
 }
 .site-footer a {
     padding-left: 2ch;
-    font-family: "Noto Serif", "DejaVu Serif", serif;
     font-style: normal;
     text-decoration: none;
     white-space: nowrap;


### PR DESCRIPTION
I noticed in some cases that the browser was falling back to the default font in cases where previously the site’s custom fonts would have been used. This turned out to be from code blocks not having a font specified, and from the header and footer referring to the removed Noto Sans.