### PR TITLE
Fix typo

### DIFF
--- a/_posts/2021-02-14-for-the-love-of-macros.adoc
+++ b/_posts/2021-02-14-for-the-love-of-macros.adoc
@@ -67,7 +67,7 @@ You can supply custom code which gets run during the build and which can read ex
 
 The beauty of this solution is that it moves all the complexity out of the language and into the build system.
 This means that you get baseline tooling support for free.
-Goto definition definition for generated code? Just works.
+Goto definition for generated code? Just works.
 Want to step into some serialization code while debugging? There's actual source code on disk, so feel free to!
 You are more of a `printf` person? Well, you'd need to convince the build system to not stomp over your changes, but, otherwise, why not?
 


### PR DESCRIPTION
definition was repeated twice. Was this intentional?