### PR TITLE
Typo fix in "Assume" block

### DIFF
--- a/_posts/2020-11-01-notes-on-paxos.adoc
+++ b/_posts/2020-11-01-notes-on-paxos.adoc
@@ -409,7 +409,7 @@ Sets:
   ℚ ∈ 2^𝔸 -- Set of quorums
 
 Assume:
-  ∀ q1, q1 ∈ ℚ: q1 ∩ q2 ≠ {}
+  ∀ q1, q2 ∈ ℚ: q1 ∩ q2 ≠ {}
 
 Vars:
   votes ∈ 2^(𝔸×𝕍) -- Set of (acceptor, value) pairs
@@ -459,7 +459,7 @@ Sets:
   ℚ ∈ 2^𝔸 -- Set of quorums
 
 Assume:
-  ∀ q1, q1 ∈ ℚ: q1 ∩ q2 ≠ {}
+  ∀ q1, q2 ∈ ℚ: q1 ∩ q2 ≠ {}
 
 Vars:
   votes ∈ 2^(𝔸×𝕍) -- Set of (acceptor, value) pairs
@@ -562,7 +562,7 @@ Sets:
   ℚ ∈ 2^𝔸 -- Set of quorums
 
 Assume:
-  ∀ q1, q1 ∈ ℚ: q1 ∩ q2 ≠ {}
+  ∀ q1, q2 ∈ ℚ: q1 ∩ q2 ≠ {}
 
 Vars:
   -- Set of (acceptor, ballot, value) triples
@@ -775,7 +775,7 @@ Sets:
   Msgs2b ≡ {type: {"2b"}, bal: 𝔹, val: 𝕍, acc: 𝔸}
 
 Assume:
-  ∀ q1, q1 ∈ ℚ: q1 ∩ q2 ≠ {}
+  ∀ q1, q2 ∈ ℚ: q1 ∩ q2 ≠ {}
 
 Vars:
   -- Set of all messages sent so far


### PR DESCRIPTION
>   ∀ q1, q1 ∈ ℚ: q1 ∩ q2 ≠ {}

Changed to:

>   ∀ q1, q2 ∈ ℚ: q1 ∩ q2 ≠ {}