### PR TITLE
Fix RSS feed URL

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
   <meta name="description"
     content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ " /feed.xml" | prepend:
+  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend:
     site.baseurl | prepend: site.url }}">
 
   <style>


### PR DESCRIPTION
There is a space that produces a 404 when the link is interpreted.