### PR TITLE
Update 2020-09-20-why-not-rust.adoc

### DIFF
--- a/_posts/2020-09-20-why-not-rust.adoc
+++ b/_posts/2020-09-20-why-not-rust.adoc
@@ -53,7 +53,7 @@ Compile times are a multiplier for everything.
 A program written in a slower to run but faster to compile programming language can be _faster_ to run because the programmer will have more time to optimize!
 
 Rust intentionally picked slow compilers in the https://research.swtch.com/generic[generics dilemma].
-This is not necessary the end of the world (the resulting runtime performance improvements are real), but it does mean that you'll have to fight tooth and nail for reasonable build times in larger projects.
+This is not necessarily the end of the world (the resulting runtime performance improvements are real), but it does mean that you'll have to fight tooth and nail for reasonable build times in larger projects.
 
 `rustc` implements what is probably the most advanced https://rustc-dev-guide.rust-lang.org/queries/incremental-compilation.html[incremental compilation] algorithm in production compilers, but this feels a bit like fighting with language compilation model.
 


### PR DESCRIPTION
Although I'm not sure: Fixing what seemed like the intended word was "necessarily" and not "necessary".