### PR TITLE
Fix rotate binary tree drop example

### DIFF
--- a/src/posts/2022-11-18-if-a-tree-falls-in-a-forest-does-it-overflow-the-stack.djot
+++ b/src/posts/2022-11-18-if-a-tree-falls-in-a-forest-does-it-overflow-the-stack.djot
@@ -131,6 +131,7 @@ impl<T> Drop for Node<T> {
           mem::swap(self, &mut *left);
           left.left = self.right.take();
           left.right = Some(right);
+          self.right = Some(left);
         }
       }
     }


### PR DESCRIPTION
Otherwise, left will just drop at the end of the block, recursively.