### PR TITLE
Fix tiny typo - Next Rust Compiler (25 Jan)

### DIFF
--- a/src/posts/2023-01-25-next-rust-compiler.dj
+++ b/src/posts/2023-01-25-next-rust-compiler.dj
@@ -60,7 +60,7 @@ Here's what I think an awesome rust compiler would do:
 : hermetic deterministic compilation
 
   It is increasingly common to want reproducible builds.
-  With NixOS and Guix, whole Linux distros are build in a deterministic fashion.
+  With NixOS and Guix, whole Linux distros are built in a deterministic fashion.
   It is possible to achieve reproducibility by carefully freezing whatever mess you are currently in, the docker way.
   But a better approach is to start with inherently pure and hermetic components, and assemble them into a larger system.
 


### PR DESCRIPTION
changed a word to past tense