### PR TITLE
Clarify Deno’s runtime and transpilation of TS

### DIFF
--- a/src/posts/2023-02-12-a-love-letter-to-deno.dj
+++ b/src/posts/2023-02-12-a-love-letter-to-deno.dj
@@ -34,7 +34,7 @@ Some manifestations of that:
 
 Deno comes with a code formatter (`deno fmt`) and an LSP server (`deno lsp`) out of the box.
 The high order bit here is not that these are high-value features which drive productivity (though that is so), but that you don't need to pull extra deps to get these features.
-Similarly, Deno is a TypeScript runtime --- there's no transpilation step involved, you just `deno main.ts`.
+~~Similarly, Deno is a TypeScript runtime --- there's no transpilation step involved~~ Similarly, you don't need to install any dependencies to transpile TypeScript and the transpilation is transparent, you just run `deno main.ts`.
 
 Deno does not rely on system's shell.
 Most scripting environments, including node, python, and ruby, make a grave mistake of adding an API to spawn a process intermediated by the shell.


### PR DESCRIPTION
Deno’s runtime is actually JS and it uses the TS compiler to convert the source to JS and it is then cached by Deno.

See the docs here for more details: https://deno.land/manual@v1.29.4/advanced/typescript/overview#how-does-it-work