### PR TITLE
Generate correct links for "fix typo" in the page footer

### DIFF
--- a/templates.ts
+++ b/templates.ts
@@ -104,7 +104,7 @@ export function page(name: string, content: HtmlString) {
     path: `/${name}`,
     title: "matklad",
     description: blurb,
-    src: `src/${name}.djot`,
+    src: `/src/${name}.dj`,
     extra_css: name === "resume" ? "resume.css" : undefined,
     content,
   });
@@ -122,7 +122,7 @@ export const post_list = (posts: Post[]): HtmlString => {
     path: "",
     title: "matklad",
     description: blurb,
-    src: "templates.ts",
+    src: "/templates.ts",
     content: html`<ul class="post-list">${list_items}</ul>`,
   });
 };


### PR DESCRIPTION
Fix the fix 🤫