### PR TITLE
Use flexbox’s `gap` property instead of `margin`s

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,12 +1,5 @@
 html { font-family: "EB Garamond", serif; font-size: 22px; line-height: 1.3em; }
 
-body {
-    max-width: 80ch;
-    padding: 2ch;
-    margin-left: auto;
-    margin-right: auto;
-}
-
 h1     { margin-bottom: 0.75rem; }
 h2, h3 { margin-bottom: 0.5rem; }
 section { margin-bottom: 1rem; }
@@ -26,16 +19,6 @@ section:target > :is(h1, h2, h3)::before { content: "§"; }
 :is(h1, h2, h3) > a { color: inherit; text-decoration:none }
 :is(h1, h2, h3) > a:hover { color: inherit; text-decoration:none }
 
-header { margin-bottom: 3rem; }
-header > nav { display: flex; column-gap: 2ch; align-items: baseline; flex-wrap: wrap; }
-header a { font-style: normal; color: rgba(0, 0, 0, .8); text-decoration: none; }
-header a:hover { color: rgba(0, 0, 0, .8); text-decoration: underline; }
-header .title { font-size: 1.25em; flex-grow: 2; }
-
-footer { margin-top: 2rem; }
-footer > p { display: flex; column-gap: 2ch; justify-content: center; flex-wrap: wrap; }
-footer a { color: rgba(0, 0, 0, .8); text-decoration: none; white-space: nowrap; }
-footer i { vertical-align: middle; color: rgba(0, 0, 0, .8) }
 
 /* Block */
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,5 +1,12 @@
 html { font-family: "EB Garamond", serif; font-size: 22px; line-height: 1.3em; }
 
+body {
+    max-width: 80ch;
+    padding: 2ch;
+    margin-left: auto;
+    margin-right: auto;
+}
+
 h1     { margin-bottom: 0.75rem; }
 h2, h3 { margin-bottom: 0.5rem; }
 section { margin-bottom: 1rem; }
@@ -10,6 +17,7 @@ sup, sub { line-height: 0; }
 h1, h2, h3 {
     font-size: 1.5rem;
     font-family: "Open Sans", sans-serif;
+    font-weight: 300;
     color: #ba3925;
     text-rendering: optimizeLegibility;
     line-height: 1em;
@@ -18,6 +26,16 @@ section:target > :is(h1, h2, h3)::before { content: "§"; }
 :is(h1, h2, h3) > a { color: inherit; text-decoration:none }
 :is(h1, h2, h3) > a:hover { color: inherit; text-decoration:none }
 
+header { margin-bottom: 3rem; }
+header > nav { display: flex; column-gap: 2ch; align-items: baseline; flex-wrap: wrap; }
+header a { font-style: normal; color: rgba(0, 0, 0, .8); text-decoration: none; }
+header a:hover { color: rgba(0, 0, 0, .8); text-decoration: underline; }
+header .title { font-size: 1.25em; flex-grow: 2; }
+
+footer { margin-top: 2rem; }
+footer > p { display: flex; column-gap: 2ch; justify-content: center; flex-wrap: wrap; }
+footer a { color: rgba(0, 0, 0, .8); text-decoration: none; white-space: nowrap; }
+footer i { vertical-align: middle; color: rgba(0, 0, 0, .8) }
 
 /* Block */
 

--- a/templates.ts
+++ b/templates.ts
@@ -38,6 +38,25 @@ export const base = (
   }
 
   * { box-sizing: border-box; margin: 0; padding: 0; margin-block-start: 0; margin-block-end: 0; }
+
+  body {
+    max-width: 80ch;
+    padding: 2ch;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  header { margin-bottom: 3rem; }
+  header > nav { display: flex; column-gap: 2ch; align-items: baseline; flex-wrap: wrap; }
+  header a { font-style: normal; color: rgba(0, 0, 0, .8); text-decoration: none; }
+  header a:hover { color: rgba(0, 0, 0, .8); text-decoration: underline; }
+  header .title { font-size: 1.25em; flex-grow: 2; }
+
+  footer { margin-top: 2rem; }
+  footer > p { display: flex; column-gap: 2ch; justify-content: center; flex-wrap: wrap; }
+  footer a { color: rgba(0, 0, 0, .8); text-decoration: none; white-space: nowrap; }
+  footer i { vertical-align: middle; color: rgba(0, 0, 0, .8) }
+
   </style>
 
   <link rel="stylesheet" href="/css/main.css">

--- a/templates.ts
+++ b/templates.ts
@@ -38,23 +38,6 @@ export const base = (
   }
 
   * { box-sizing: border-box; margin: 0; padding: 0; margin-block-start: 0; margin-block-end: 0; }
-
-  h1, h2, h3 { font-weight: 300; }
-
-  body { display: flex; flex-direction: column; align-items: center; min-height: 100vh; }
-  main { display: flex; flex-direction: column; width: 100%; max-width: 80ch; padding-left: 2ch; padding-right: 2ch; }
-
-  header { width: 100%; max-width: 80ch; margin-bottom: 1.5rem; }
-  header > nav { display: flex; flex-wrap: wrap; justify-content: space-between; align-items: baseline; }
-  header a { font-style: normal; margin-left: 1ch; margin-right: 1ch; line-height: 1.5rem; color: rgba(0, 0, 0, .8); text-decoration: none; }
-  header a:hover { color: rgba(0, 0, 0, .8); text-decoration: underline; }
-  header .title { font-size: 1.25em; flex-grow: 2; }
-
-  footer { display: flex; justify-content: center; align-items: baseline; width: 100%; max-width: 80ch; margin-top: 1rem; height: 2rem; padding-left: 1ch; padding-right: 1ch; }
-  footer > p { margin-bottom: 0; }
-  footer a { padding-left: 2ch; font-style: normal; color: rgba(0, 0, 0, .8); text-decoration: none; white-space: nowrap; }
-  footer i { vertical-align: middle; color: rgba(0, 0, 0, .8) }
-
   </style>
 
   <link rel="stylesheet" href="/css/main.css">


### PR DESCRIPTION
## Changes 

This pull request makes five interrelated changes, the first of which is the most significant:

- modifies how header and footer styling work by using flexbox `gap` instead of manual `margin` and `padding`
- moves `max-width` to `<body>` instead of duplicating this property on `<header>`, `<main>` and `<footer>`
- moves `padding` from `<main>` and `<footer>` to `<body>`; this way, the header is now padded from the edge of the viewport, which I personally think is more visually appealing. Feel free to revert this part if you like!
- moves `h1, h2, h3 { font-weight: 300 }` from `template.ts` to `main.css` where all other heading styling is located
- uses `margin-left: auto; margin-right: auto` to center the page’s content horizontally instead of using flexbox. Again, this is subjective, but I personally think it makes sense to just use a simple tool like `margin` for this instead of flexbox.

#### Changes to header and footer styling

Both of these involve placing multiple elements next to each other horizontally, with a gap in-between each element. Previously, these gaps was created with `margin-left`/`margin-right` for the links in the header, and `padding-left` for the links in the footer. Now, these gaps are created using flexbox’s `column-gap` property.

WIth the old approach, even the first element in the footer received a `padding-left`. This meant that the entire footer’s width was slightly wider than the actual width of the displayed content, which in turn caused the footer’s centering to shift the footer slightly too far to the right.

## Screenshots

At extremely small viewport sizes, this pull request coincidentally improves wrapping behavior for the header and footer:

<table>
<tr>
<th>Before</th><th>After</th>
</tr>

<tr>
<td><img alt="Screenshot 2023-03-06 at 4 33 24 pm" src="https://user-images.githubusercontent.com/31783266/223028663-5287d61e-6048-45bf-85ec-6f8b667a2cfc.png"></td>
<td><img alt="Screenshot 2023-03-06 at 4 33 33 pm" src="https://user-images.githubusercontent.com/31783266/223028684-c000708f-4701-405a-8c6f-1df11656cbb2.png"></td>
</tr>

<tr>
<td><img alt="Screenshot 2023-03-06 at 4 32 56 pm" src="https://user-images.githubusercontent.com/31783266/223028976-b0784133-e594-4a4d-bf24-6e88c167183d.png"></td>
<td><img alt="Screenshot 2023-03-06 at 4 33 02 pm" src="https://user-images.githubusercontent.com/31783266/223029099-4ef7f44d-a89d-404d-9f8a-5e6723c00f23.png"></td>
</tr>
</table>

This pull request has no major effects when viewing the page at desktop viewport sizes:

<table>
<tr>
<th>Before</th><th>After</th>
</tr>

<tr>
<td><img alt="Screenshot 2023-03-06 at 4 34 21 pm" src="https://user-images.githubusercontent.com/31783266/223028366-bf45ead5-135d-47b4-8e31-a922dc3139ee.png"></td>
<td><img alt="Screenshot 2023-03-06 at 4 34 24 pm" src="https://user-images.githubusercontent.com/31783266/223028436-63b7a518-5b77-47a6-8e3a-98910a48ef40.png"></td>
</tr>

<tr>
<td><img alt="Screenshot 2023-03-06 at 4 41 20 pm" src="https://user-images.githubusercontent.com/31783266/223028619-ec8ca314-17af-49d9-a6c1-45896a6b898a.png"></td>
<td><img alt="Screenshot 2023-03-06 at 4 41 23 pm" src="https://user-images.githubusercontent.com/31783266/223028635-1682105c-1909-42b6-912e-6c70691b3ba5.png"></td>
</tr>
</table>