### PR TITLE
Update outdated rust issues link for unsoundness bugs

### DIFF
--- a/src/posts/2020-09-20-why-not-rust.dj
+++ b/src/posts/2020-09-20-why-not-rust.dj
@@ -154,7 +154,7 @@ So, here's my attempt to argue _against_ Rust:
   Two such extensions might be fine in isolation, but lead to undefined behavior if used simultaneously:
   [Observational equivalence and unsafe code](https://smallcultfollowing.com/babysteps/blog/2016/10/02/observational-equivalence-and-unsafe-code/).
 
-  Finally, there are outright [bugs in the compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3A%22I-unsound+%F0%9F%92%A5%22++).
+  Finally, there are outright [bugs in the compiler](https://github.com/rust-lang/rust/issues?q=is%3Aopen+label%3AI-unsound+sort%3Aupdated-desc).
 
 ---
 


### PR DESCRIPTION
While reading [Why Not Rust](https://matklad.github.io/2020/09/20/why-not-rust.html) I saw that the GitHub issues link for the unsoundness label doesn't work as intended. The link was

```
https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3A%22I-unsound+%F0%9F%92%A5%22++
```
Which has the emoji 💥 for the label `label:"I-unsound 💥"`, but this seems to have been updated to remove the emoji, with the new label being the more boring `label:I-unsound`.

This commit fixes the old link to use the new label.
