### PR TITLE
Fix broken link on Notes-on-paxos

### DIFF
--- a/src/posts/2020-11-01-notes-on-paxos.dj
+++ b/src/posts/2020-11-01-notes-on-paxos.dj
@@ -1,6 +1,6 @@
 # Notes on Paxos
 
-These are my notes after learning the [Paxos](https://en.wikipedia.org/wiki/Paxos_(computer_science)) algorithm.
+These are my notes after learning the [Paxos](<https://en.wikipedia.org/wiki/Paxos_(computer_science)>) algorithm.
 The primary goal here is to sharpen my own understanding of the algorithm, but maybe someone will find this explanation of Paxos useful!
 This post assumes fluency with mathematical notation.
 


### PR DESCRIPTION
Seems some markdown processors don't handle parentheses well. 

I looked at https://meta.stackexchange.com/a/13509 for suggestions, so if it doesn't work I would suggest just trying %29 instead of ')'