### PR TITLE
Update 2023-05-21-resilient-ll-parsing-tutorial.dj

### DIFF
--- a/src/posts/2023-05-21-resilient-ll-parsing-tutorial.dj
+++ b/src/posts/2023-05-21-resilient-ll-parsing-tutorial.dj
@@ -816,7 +816,7 @@ fn expr_delimited(p: &mut Parser) -> MarkClosed { <1>
   ...
 }
 
-fn expr(p: &mut Parser, left: TokenKind) {
+fn expr(p: &mut Parser) {
   let mut lhs = expr_delimited(p); <1>
 
   // ExprCall = Expr ArgList


### PR DESCRIPTION
`left` is not used in this version of the function. I believe it is a typo, because it appears in `expr_rec` in the code below.