### PR TITLE
Fixed typo

### DIFF
--- a/src/posts/2023-08-13-role-of-algorithms.dj
+++ b/src/posts/2023-08-13-role-of-algorithms.dj
@@ -230,7 +230,7 @@ the list from the last post, but with explicit connections to other things:
 : Floyd-Warshall
 
   This one is cool! Everybody knows why any regular expression can be complied to an equivalent
-  finite state machine. Few people know the reverse, why each automaton has an equivalent reges
+  finite state machine. Few people know the reverse, why each automaton has an equivalent regex
   (many people know this fact, but few understand why). Well, because Floyd-Warshall! To convert an
   automaton to regex use the same algorithm you use to find pairwise distances in a graph.
 


### PR DESCRIPTION
I think this word was meant to be "regex", not "reges" :slightly_smiling_face:. Nice post as usual by the way.