### PR TITLE
an utility => a utility

### DIFF
--- a/src/posts/2023-08-17-typescript-is-surprisingly-ok-for-compilers.dj
+++ b/src/posts/2023-08-17-typescript-is-surprisingly-ok-for-compilers.dj
@@ -346,7 +346,7 @@ interface TypeError {
 }
 ```
 
-To check ifs and binary expressions, we would also need an utility for comparing types:
+To check ifs and binary expressions, we would also need a utility for comparing types:
 
 ```ts
 function type_equal(lhs: Type, rhs: Type): boolean {


### PR DESCRIPTION
Even though "utility" starts with a vowel, it is pronounced with a consonant sound first "yoo-tility"