### PR TITLE
Update 2022-04-25-why-lsp.dj – fix typo C++ vs C#

### DIFF
--- a/src/posts/2022-04-25-why-lsp.dj
+++ b/src/posts/2022-04-25-why-lsp.dj
@@ -76,7 +76,7 @@ Language servers are a counter example to the ["never rewrite"](https://www.joel
 Majority of well regarded language servers are rewrites or alternative implementations of batch compilers.
 
 Both IntelliJ and Eclipse wrote their own compilers rather than re-using javac inside an IDE.
-To provide an adequate IDE support for C#, Microsoft rewrote their C++ batch compiler into an interactive self-hosted one (project Roslyn).
+To provide an adequate IDE support for C#, Microsoft rewrote their C# batch compiler into an interactive self-hosted one (project Roslyn).
 Dart, despite being a from-scratch, relatively modern language, ended up with _three_ implementations (host AOT compiler, host IDE compiler (dart-analyzer), on-device JIT compiler).
 Rust tried both --- incremental evolution of rustc (RLS) and from-scratch implementation (rust-analyzer), and rust-analyzer decisively won.
 


### PR DESCRIPTION
Did Microsoft rewrite **C++**-compiler to C# compiler? If so could you provide some links to read more about it please