### PR TITLE
fix: update comparison

### DIFF
--- a/src/posts/2023-09-13-comparative-analysis.dj
+++ b/src/posts/2023-09-13-comparative-analysis.dj
@@ -46,7 +46,7 @@ x < lo or hi < x
 Segment `a` is inside segment `b`:
 
 ```zig
-b.start <= a.start and a.end <= b.start
+b.start <= a.start and a.end <= b.end
 ```
 
 Segments `a` and `b` are disjoint (either `a` is to the left of `b` or `a` is to the right of `b`):


### PR DESCRIPTION
```

    |-------a-------|
|-----------b-----------|

```

For `a` to be inside of `b` the following must be true:
* `a.start >= b.start`, which we flip to `b.start <= a.start`
* `a.end <= b.end`