### PR TITLE
malloc uses heap, not stack

### DIFF
--- a/content/posts/2023-03-26-zig-and-rust.dj
+++ b/content/posts/2023-03-26-zig-and-rust.dj
@@ -16,7 +16,7 @@ To the first approximation, we all strive to write bug-free programs.
 But I think a closer look reveals that we don't actually care about programs being correct 100% of the time, at least in the majority of the domains.
 Empirically, almost every program has bugs, and yet it somehow works out OK.
 To pick one specific example, most programs use stack, but almost no programs understand what their stack usage is exactly, and how far they can go.
-When we call `malloc`, we just hope that we have enough stack space for it, we almost never check.
+When we call `malloc`, we just hope that we have enough heap space for it, we almost never check.
 Similarly, all Rust programs abort on OOM, and can't state their memory requirements up-front.
 Certainly good enough, but not perfect.
 


### PR DESCRIPTION
Not sure whether mentioning heap space after stating that you'll give an example of stack space makes sense, but at least it fixes the old claim that malloc() its space comes from the stack. I'll leave the option to reword it up to you.