### PR TITLE
fix code typo

### DIFF
--- a/content/posts/2022-10-06-hard-mode-rust.dj
+++ b/content/posts/2022-10-06-hard-mode-rust.dj
@@ -839,7 +839,7 @@ The thing actually works, miri complaints notwithstanding!
 Actually, I am impressed.
 I was certain that this won't actually work out, and that I'd have to write copious amount of unsafe to get the runtime behavior I want.
 Specifically, I believed that `&'m mut T<'m>` variance issue would force my hand to add `'m`, `'mm`, `'mmm` and further lifetimes, but that didn't happen.
-For "owning" pointers, `&'m mut T<'m'>` turned out to work fine!
+For "owning" pointers, `&'m mut T<'m>` turned out to work fine!
 It's only when processing you might need extra lifetimes.
 `Parser<'m, 'i, 'a>` is at least two lifetimes more than I am completely comfortable with, but I guess I can live with that.
 


### PR DESCRIPTION
change lifetime annotation `<'m'>`, to `<'m>`