### PR TITLE
Fixes typo in git command 

### DIFF
--- a/content/posts/2024-07-25-git-worktrees.dj
+++ b/content/posts/2024-07-25-git-worktrees.dj
@@ -135,7 +135,7 @@ Specifically:
   # a PR is opened!
 
   $                              |
-  $ git push --fore-with-lease   | $ ./zig/zig build fuzz
+  $ git push --force-with-lease   | $ ./zig/zig build fuzz
   $ gh pr create --web           | # Still hasn't failed
   $                              |
   ```


### PR DESCRIPTION
typo `--fore-with-lease` => `--force-with-lease`