### PR TITLE
Typo fix: "log-running" -> "long-running"

### DIFF
--- a/content/posts/2024-07-25-git-worktrees.dj
+++ b/content/posts/2024-07-25-git-worktrees.dj
@@ -76,7 +76,7 @@ Specifically:
 * The *review* worktree, where I checkout code for code review. While I can't review code and write
   code at the same time, there is one thing I am implementing, and one thing I am reviewing, but the
   review and implementation proceed concurrently.
-* Then, there's *fuzz* tree, where I run log-running fuzzing jobs for the code I am actively working
+* Then, there's *fuzz* tree, where I run long-running fuzzing jobs for the code I am actively working
   on. My overall idealized feature workflow looks like this:
 
   ```console


### PR DESCRIPTION
One character typo-fix.