### PR TITLE
2024-08-01-primitive-recursive-functions.dj: fix typo

### DIFF
--- a/content/posts/2024-08-01-primitive-recursive-functions.dj
+++ b/content/posts/2024-08-01-primitive-recursive-functions.dj
@@ -437,7 +437,7 @@ And a somewhat depressing result here is that there are no non-trivial refactori
 properties that you can algorithmically check.
 
 Suppose we have some magic TM, called P, which checks such a property. Let's show that, using P, we can
-solve the problem we know we can not solve --- the halting program.
+solve the problem we know we can not solve --- the halting problem.
 
 Consider a Turing Machine that is just an infinite loop and never terminates, M1. P might or might
 not hold for it. But, because P is not-trivial (it holds for some machines and doesn't hold for some

--- a/content/posts/2024-08-01-primitive-recursive-functions.dj
+++ b/content/posts/2024-08-01-primitive-recursive-functions.dj
@@ -293,7 +293,7 @@ called a pushdown automaton, and it would correspond to context-free languages. 
 the scope of this post!
 
 There's yet another way to look at the tape, or the pair of stacks, if the set of symbols is 0 and
-1. You could say that a stack is just number! So, something like
+1. You could say that a stack is just a number! So, something like
 `[1, 0, 1, 1]`{.display}
 will be
 [`1 + 2 + 8 = 11`.]{.display}

--- a/content/posts/2024-08-01-primitive-recursive-functions.dj
+++ b/content/posts/2024-08-01-primitive-recursive-functions.dj
@@ -114,7 +114,7 @@ sets of strings that couldn't be recognized by an FSM. Consider this set:
 ```
 
 That is, an infinite set which contains '1's surrounded by the equal number of '0's on the both
-sides. Let's proove that there isn't a state machine that recognizes this set!
+sides. Let's prove that there isn't a state machine that recognizes this set!
 
 As usually, suppose there _is_ such a state machine. It has a certain number of states --- maybe a
 dozen, maybe a hundred, maybe a thousand, maybe even more. But let's say fewer than a million.

--- a/content/posts/2024-08-01-primitive-recursive-functions.dj
+++ b/content/posts/2024-08-01-primitive-recursive-functions.dj
@@ -285,7 +285,7 @@ That is, everything to the left of the head is one stack, everything to the righ
 other.  Here, moving the reading head left or right corresponds to popping a value off one stack and
 pushing it onto another.
 
-So, an equivalent-in-power definition would be to say that an TM is an FSM endowed with a two
+So, an equivalent-in-power definition would be to say that an TM is an FSM endowed with two
 stacks.
 
 This of course creates an obvious question: is an FSM with just one stack a thing? Yes! It would be


### PR DESCRIPTION
Proove -> prove, a two -> two, just number -> just a number, halting program -> halting problem