### PR TITLE
make note less ambiguous

### DIFF
--- a/content/posts/2025-03-19-comptime-zig-orm.dj
+++ b/content/posts/2025-03-19-comptime-zig-orm.dj
@@ -233,8 +233,8 @@ insufficient balance). For simplicity, I choose to model this by returning a `nu
 
 ::: note
 In Zig, types are always specified in prefix notation, without exception. For example,
-`[3]?struct { r: u8, g: u8, b:u8 }`{.display}
-is an array of three optional colors.
+`[2]?struct { r: u8, g: u8, b: u8 }`{.display}
+is an array of two optional color triplets.
 :::
 
 Let's see the implementation of `create_transfer`:


### PR DESCRIPTION
The original wording could be interpreted ambiguously about whether individual color components or whole colors were optional. The example now clarifies that each array element is either a complete struct or null. The array length was changed from 3 to 2 to avoid confusion from the three in the triplet and array item count and spacing after colons was adjusted for consistency.