### PR TITLE
“A URL” vs “An URL”

### DIFF
--- a/content/posts/2025-04-22-horizontal-scroll.dj
+++ b/content/posts/2025-04-22-horizontal-scroll.dj
@@ -114,7 +114,7 @@ aside.admn > div { flex: 1; min-width: 0; }
 ```
 
 That's all for today. To underscore my point, and in solidarity with the authors of the two blogs
-that started this, let me include an url without `word-break` to make sure this article itself has
+that started this, let me include a url without `word-break` to make sure this article itself has
 the problem it talks about:
 
 ```=html


### PR DESCRIPTION
I did a brief search comparing “a URL” to “an URL” and found a Quora, and Stack Exchange response, as well as a few other sites, all concurring with “a URL” but none terribly authoritative sites.

However; MDN uses “a URL,” albeit not explicitly saying “a” vs “an.”  https://developer.mozilla.org/en-US/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_URL

It looks as though there are two instances in the repo of “a URL” and three instances of “an URL” including this one, so perhaps this isn’t something that will be resolved right now, and which instead you’ll want to look into.

It’s very late here though, so I’m signing off! But I greatly enjoy reading your blog in the evenings and am always excited when I check your site and see a new one.