### PR TITLE
Fix remaining instances of "an URL" to "a URL"

### DIFF
--- a/content/posts/2021-07-30-shell-injection.dj
+++ b/content/posts/2021-07-30-shell-injection.dj
@@ -118,7 +118,7 @@ execve("/bin/curl", ["curl", "https://example.com"], 0xec4008)
 ```
 
 The first `execve` we see here is our original invocation of the `node` binary itself.
-The last one is what we want to do --- spawn `curl` with a single argument, an url.
+The last one is what we want to do --- spawn `curl` with a single argument, a url.
 And the middle one is what node's `exec` actually does.
 
 Let's take a closer look:

--- a/content/posts/2024-12-30-what-is-dependency.dj
+++ b/content/posts/2024-12-30-what-is-dependency.dj
@@ -35,7 +35,7 @@ the rest of the hashes.
 ## Location
 
 Location is the suggested way to acquire dependency. It is something that tells you how to get a
-file tree that matches the checksum you already know. Typically, a location is just an URL.
+file tree that matches the checksum you already know. Typically, a location is just a URL.
 
 If a dependency is identified via a checksum, than there might be several locations. In fact, common
 scenarios would have at least three or four:


### PR DESCRIPTION
Per consensus in https://github.com/matklad/matklad.github.io/pull/259,  fix remaining instances of "an URL" to "a URL."