### PR TITLE
 Changes for 2018 Posts

### DIFF
--- a/content/posts/2018-05-03-effective-pull-requests.dj
+++ b/content/posts/2018-05-03-effective-pull-requests.dj
@@ -74,7 +74,7 @@ branch to track the master from upstream:
 ```console
 $ git clone git@github.com:matklad/cargo.git && cd cargo
 $ git remote add upstream git@github.com:rust-lang/cargo.git
-$ git fetch remote
+$ git fetch upstream
 $ git branch --set-upstream-to=upstream/master
 ```
 

--- a/content/posts/2018-05-24-typed-key-pattern.dj
+++ b/content/posts/2018-05-24-typed-key-pattern.dj
@@ -65,7 +65,7 @@ string literal and specify its type on the call site:
 ```rust
 impl Config {
     fn get<T: Deserialize>(&self, key: &str) -> Result<T> {
-        let json_value = self.map.get("key")
+        let json_value = self.map.get(key)
             .ok_or_else(|| bail!("key is missing: `{}`", key))?;
         Ok(T::deserialize(json_value)?)
     }

--- a/content/posts/2018-06-06-modern-parser-generator.dj
+++ b/content/posts/2018-06-06-modern-parser-generator.dj
@@ -486,7 +486,7 @@ fn parse_t() {
 
 The theoretical problem here is that it can't deal with
 left-recursion. That is, rules like `Statements -> Statements ';'
-OneStatement` make recursive descent parser to loop infinitely. In
+OneStatement` make recursive descent parsers loop infinitely. In
 theory, this problem is solved by rewriting the grammar and
 eliminating the left recursion. If you had a formal grammars class,
 you probably have done this! In practice, this is a completely

--- a/content/posts/2018-07-24-exceptions-in-structured-concurrency.dj
+++ b/content/posts/2018-07-24-exceptions-in-structured-concurrency.dj
@@ -62,7 +62,7 @@ unwinding which I feel we should really try to solve better: if you
 have a bunch of threads running, and one of them catches fire, what
 happens? It turns out that often nothing particular happens: some more
 threads might die from the poisoned mutexes and closed channels, but
-other treads might continue, and, as a result the application will
+other threads might continue, and, as a result the application will
 exist in a half-dead state for indefinite period of time.
 
 


### PR DESCRIPTION
Fixes for typos, grammar, and code formatting.