### PR TITLE
fix: a couple typos

### DIFF
--- a/content/posts/2025-08-09-zigs-lovely-syntax.dj
+++ b/content/posts/2025-08-09-zigs-lovely-syntax.dj
@@ -319,7 +319,7 @@ syntactically.
 
 I have a very strong opinion about variable shadowing. It goes both ways: I spent hours debugging
 code which incorrectly tried to use a variable that was shadowed by something else, but I also spent
-hours debugging code that accidentally used the an variable that should have been shadowed! I really
+hours debugging code that accidentally used a variable that should have been shadowed! I really
 don't know whether on balance it is better to forbid or encourage shadowing!
 
 Zig of course forbids shadowing, but what's curious is that it's just on episode of the large
@@ -338,7 +338,7 @@ const ArrayList = std.ArrayList;
 
 Zig doesn't have inheritance, mixins, argument-dependent lookup, extension functions, implicit or
 traits, so, if you see `x.foo()`, that `foo` is guaranteed to be a boring method declared on `x`
-type. Similarly, while ZIg has powerful comptime capabilities, it
+type. Similarly, while Zig has powerful comptime capabilities, it
 [intentionally disallows](https://matklad.github.io/2025/04/19/things-zig-comptime-wont-do.html)
 declaring methods at compile time.
 


### PR DESCRIPTION
- `the an` -> `a`
- `ZIg` -> `Zig`