### PR TITLE
Remove duplicate 'strong exception safety` in 2025-08-16-reserve-firs…

### DIFF
--- a/content/posts/2025-08-16-reserve-first.dj
+++ b/content/posts/2025-08-16-reserve-first.dj
@@ -121,7 +121,7 @@ error happens midway, there are three possible outcomes:
 
 : Strong Exception Safety
 
-  The object state remains as if we didn't attempt the operation (strong exception safety).
+  The object state remains as if we didn't attempt the operation.
 
 : Basic Exception Safety
 


### PR DESCRIPTION
I am not 100% sure if this really was unintentional, but to me, it seems like a leftover. Either way, thanks for the great post!