### PR TITLE
look-for-bugs: remove repeated 'all'

### DIFF
--- a/content/posts/2025-09-04-look-for-bugs.dj
+++ b/content/posts/2025-09-04-look-for-bugs.dj
@@ -62,7 +62,7 @@ use these two other frames:
 
 : Stare at the state
 
-  Identify the key data structures and fields, and search for all all places where they are
+  Identify the key data structures and fields, and search for all places where they are
   created and modified.
 
 You want to see a slice across space and time, state and control flow (c.f.


### PR DESCRIPTION
Altough this might be on purpose to create emphasis, it seems to me like it wasn't.