### PR TITLE
Fix subtle typo in IntelliJ-Rust plugin naming: "IntelljJ" -> "IntelliJ"

### DIFF
--- a/content/resume.dj
+++ b/content/resume.dj
@@ -173,7 +173,7 @@ and "Python" courses.
 <https://intellij-rust.github.io>
 
 At JetBrains, I have led the development of
-[IntelljJ-Rust](http://github.com/intellij-rust/intellij-rust) plugin for the Rust
+[IntelliJ-Rust](http://github.com/intellij-rust/intellij-rust) plugin for the Rust
 programming language. The plugin is a Rust "compiler" written in Kotlin, with
 full-blown parser, name resolution and type inference algorithms, and
 integrations with build tools and debuggers. Besides solving the technical


### PR DESCRIPTION
Fix a subtle typo in your résumé: `IntelljJ` -> `IntelliJ`.