### PR TITLE
Fix typo in discussion of null vs undefined

### DIFF
--- a/content/posts/2026-01-20-vibecoding-2.dj
+++ b/content/posts/2026-01-20-vibecoding-2.dj
@@ -285,7 +285,7 @@ vibe-coding session transpired --- I was providing structure, Claude was paintin
 In particular, with that CLI parsing structure in place, Claude had little problem adding new
 subcommands and new arguments in a satisfactory way. The only snag was that, when I asked to add an
 optional path to `sync`, it went with `string | null`, while I strongly prefer `string | undefined`.
-Obviously, its better to pick your null in JavaScript and stick with it. The fact that `undefineed`
+Obviously, its better to pick your null in JavaScript and stick with it. The fact that `undefined`
 is unavoidable predetermines the winner. Given that the argument was added as an incremental small
 change, course-correcting was trivial.
 


### PR DESCRIPTION
Corrected a typo from 'undefineed' to 'undefined' in the text discussing JavaScript null vs undefined.