### PR TITLE
fix typo in strictly monotonic time

### DIFF
--- a/content/posts/2026-01-23-strictly-monotonic-time.dj
+++ b/content/posts/2026-01-23-strictly-monotonic-time.dj
@@ -42,5 +42,5 @@ instances, they must have been ultimately derived from the exact same call to `n
 fundamentally less ambiguous.
 
 The constraint here is that the resolution of the time value (_not_ the clock resolution) needs to
-be hight enough, to make sure that repeated `+1` don't move you into the future, but nanosecond
+be high enough, to make sure that repeated `+1` don't move you into the future, but nanosecond
 precision seems fine for that.


### PR DESCRIPTION
fix "be hight enough" -> "be high enough"