### PR TITLE
Change return type of children function to Node.Data

### DIFF
--- a/content/posts/2025-12-23-zig-newtype-index-pattern.dj
+++ b/content/posts/2025-12-23-zig-newtype-index-pattern.dj
@@ -145,7 +145,7 @@ const ItemIndex = enum(u32) {
     pub fn children(
         tree: *const Tree,
         node: Node,
-    ) []const Node {
+    ) []const Node.Data {
         const range = tree.get(node).children;
         return tree.nodes[range.index..][0..range.count];
     }


### PR DESCRIPTION
Unless keeping a separate slice attribute of []Node children is desired to allow a return type of []Node, this fixes an incorrect return type for the children method but sacrifices knowing their id’s