### PR TITLE
Fix typo in test case minimization documentation

### DIFF
--- a/content/posts/2026-04-20-test-case-minimization.dj
+++ b/content/posts/2026-04-20-test-case-minimization.dj
@@ -139,7 +139,7 @@ hassle.
 
 From an arbitrary int, we can generate an int in range. As per
 [_Random Numbers Included_](https://matklad.github.io/2025/03/31/random-numbers-included.html),
-we use a closed range, which makes the API infailable and is usually more convenient at the
+we use a closed range, which makes the API infallible and is usually more convenient at the
 call-site:
 
 ```zig


### PR DESCRIPTION
Corrected a typo from 'infailable' to 'infallible' in the documentation.