### PR TITLE
Changes for 2023 Posts (1/5)

### DIFF
--- a/content/posts/2023-01-25-next-rust-compiler.dj
+++ b/content/posts/2023-01-25-next-rust-compiler.dj
@@ -23,9 +23,9 @@ Here's what I think an awesome rust compiler would do:
 : rust-native compilation model
 
   Like C++, Rust (ab)uses the C compilation model --- compilation units are separately compiled into object files, which are then linked into a single executable by the linker.
-  This model is at odds with how the language work.
+  This model is at odds with how the language works.
   In particular, compiling a generic function isn't actually possible until you know specific type parameters at the call-site.
-  Rust and C++ hack around that by compiling a separate copy for every call-site (C++ even re-type-checks every call-site), and deduplicating instantiations during the link step.
+  Rust and C++ hack around that by compiling a separate copy for every call-site (C++ even re-typechecks every call-site), and deduplicating instantiations during the link step.
   This creates a lot of wasted work, which is only there because we try to follow "compile to object files then link" model of operation.
   It would be significantly more efficient to merge compiler and linker, such that only the minimal amount of code is compiled, compiled code is fully aware about surrounding context and can be inlined across crates, and where the compilation makes the optimal use of all available CPU and RAM.
 
@@ -51,11 +51,11 @@ Here's what I think an awesome rust compiler would do:
 
   However, for more complex projects you want to have more direct relationship with the code.
   You want tools other than compiler to understand the meaning of the code, and to act on it.
-  For example automated large scale refactors and code analysis, project-specific linting rules or formal proofs of correctness all could benefit from having an access to semantically rich model of the language.
+  For example, automated large scale refactors and code analysis, project-specific linting rules or formal proofs of correctness could all benefit from having access to a semantically rich model of the language.
 
-  Providing such semantic  model, where AST is annotated with resolved names, inferred types, and bodies are converted to a simple and precise IR, is a huge ask.
+  Providing such a semantic model, where the AST is annotated with resolved names, inferred types, and bodies are converted to a simple and precise IR, is a huge ask.
   Not because it is technically hard to implement, but because this adds an entirely new stable API to the language.
-  Nonetheless, such an API would unlock quite a few use cases, so the tradeoff is worth it.
+  Nonetheless, such an API would unlock quite a few use cases, so the trade-off is worth it.
 
 : hermetic deterministic compilation
 
@@ -75,7 +75,7 @@ Here's what I think an awesome rust compiler would do:
   For the task of providing immediate feedback right in the editor when the user types the code, compilation "pipeline" needs to be changed significantly.
   It should be lazy (so that only the minimal amount of code is inspected and re-analyzed on typing) and resilient and robust to errors (IDE job mostly ends when the code is error free).
   [rust-analyzer](https://rust-analyzer.github.io) shows one possible way to do that, with the only drawback of being a completely separate tool for IDE, and only IDE.
-  There's no technical limitation why the full compiler can't be like that, just the organizational limitation of it being very hard to re-architecture existing entrenched code, perfected for its local optimum.
+  There's no technical limitation why the full compiler can't be like that, just the organizational limitation of it being very hard to re-architect existing entrenched code, perfected for its local optimum.
 
 : `cargo install rust-compiler`
 

--- a/content/posts/2023-02-10-how-a-zig-ide-could-work.dj
+++ b/content/posts/2023-02-10-how-a-zig-ide-could-work.dj
@@ -13,9 +13,9 @@ It's useful to discuss a bit how the compiler works today.
 For something more thorough, refer to this excellent series of posts: <https://mitchellh.com/zig>.
 
 First, each Zig file is parsed into an AST.
-Delightfully, parsing doesn't require any context whatsoever, it's a pure `[]const u8 -> Ast` function, and the resulting Ast is just a piece of data.
+Delightfully, parsing doesn't require any context whatsoever, it's a pure `[]const u8 -> Ast` function, and the resulting AST is just a piece of data.
 
-After parsing, the Ast is converted to an intermediate representation, Zir.
+After parsing, the AST is converted to an intermediate representation, Zir.
 This is where Zig diverges a bit from more typical statically compiled languages.
 Zir actually resembles something like Python's bytecode --- an intermediate representation that an interpreter for a dynamically-typed language would use.
 That's because it _is_ an interpreter's IR --- the next stage would use Zir to evaluate comptime.
@@ -24,14 +24,14 @@ Let's look at an example:
 
 ```zig
 fn generic_add(comptime T: type, lhs: T, rhs: T) T {
-  return lhs + rhs;
+    return lhs + rhs;
 }
 ```
 
 Here, the Zir for `generic_add` would encode addition as a typeless operation, because we don't know types at this point.
 In particular, `T` can be whatever.
 When the compiler would _instantiate_ `generic_add` with different `T`s, like `generic_add(u32, ...)`, `generic_add(f64, ...)`, it will re-use the same Zir for different instantiations.
-That's the two purposes of Zir: to directly evaluate code at compile time, and to serve as a template for monomorphisation.
+That's the two purposes of Zir: to directly evaluate code at compile time, and to serve as a template for monomorphization.
 
 The next stage is where the magic happens --- the compiler partially evaluates dynamically typed Zir to convert it into a fairly standard statically typed IR.
 The process starts at the `main` function.
@@ -46,7 +46,7 @@ const T = u8;
 const x = generic_add(T, a, b);
 ```
 
-the compiler monomorphises the generic call.
+the compiler monomorphizes the generic call.
 It checks that all comptime arguments (`T`) are fully evaluated, and starts partial evaluation of the called function, with comptime parameters fixed to particular values (this of course is memoized).
 
 The whole process is lazy --- only things transitively used from main are analyzed.
@@ -103,17 +103,17 @@ There are two, separate interesting questions to ask here:
 ## Just Compile Everything
 
 It's useful to start with a pedantically correct approach.
-Let's run our usual compilation (recursively monomorphising called functions starting from the `main`).
-The result would contain a bunch of different monomorphisations of `guinea_pig`, for different values of `T`.
-For each _specific_ monomorphisation it's now clear what is the correct answer.
-For the unspecialized case as written in the source code, the IDE can now show something reasonable by combining partial results from each monomorphisation.
+Let's run our usual compilation (recursively monomorphizing called functions starting from the `main`).
+The result would contain a bunch of different monomorphizations of `guinea_pig`, for different values of `T`.
+For each _specific_ monomorphization it's now clear what is the correct answer.
+For the unspecialized case as written in the source code, the IDE can now show something reasonable by combining partial results from each monomorphization.
 
 There are several issues with this approach.
 
-_First_, collecting the _full_ set of monomorphisations is not well-defined in the presence of conditional compilation.
+_First_, collecting the _full_ set of monomorphizations is not well-defined in the presence of conditional compilation.
 Even if you run the "full" compilation starting from main, today compiler assumes some particular environment (eg, Windows or Linux), which doesn't give you a full picture.
 There's a fascinating issue about multibuilds --- making the compiler process all combinations of conditional compilation flags at the same time: [zig#3028](https://github.com/ziglang/zig/issues/3028).
-With my IDE writer hat on, I really hope it gets in, as it will move IDE support from inherently heuristic territory, to something where, in principle, there's a correct result (even if might not be particularly easy to compute).
+With my IDE writer hat on, I really hope it gets in, as it will move IDE support from inherently heuristic territory, to something where, in principle, there's a correct result (even if it might not be particularly easy to compute).
 
 The _second_ problem is that this probably is going to be much too slow.
 If you think about IDE support for the first time, a very tantalizing idea is to try to lean just into incremental compilation.
@@ -124,20 +124,20 @@ So the trick for IDE-grade interactive performance is just to implement sufficie
 The problem with sufficiently incremental compiler is that even the perfect incrementality, which does the minimal required amount of work, will be slow in a non-insignificant amount of cases.
 The nature of code is that a small change to the source in a single place might lead to a large change to resolved types all over the project.
 For examples, changing the name of some popular type invalidates all the code that uses this type.
-That's the fundamental reason why IDE try hard to maintain an ability to _not_ analyze everything.
+That's the fundamental reason why IDEs try hard to maintain the ability to _not_ analyze everything.
 
 On the other hand, at the end of the day you'll have to do this work at least by the time you run the tests.
 And Zig's compiler is written from the ground up to be very incremental and very fast, so perhaps this will be good enough?
 My current gut feeling is that the answer is no --- even if you _can_ re-analyze everything in, say, 100ms, that'll still require burning the battery for essentially useless work.
 Usually, there's a lot more atomic small edits for a single test run.
 
-The _third_ problem with the approach of collection all monomorphisations is that it simply does not work if the function isn't actually called, yet.
+The _third_ problem with the approach of collecting all monomorphizations is that it simply does not work if the function isn't actually called, yet.
 Which is common in incomplete code that is being written, exactly the use-case where the IDE is most useful!
 
 ## Compile Only What We Need
 
 Thinking about the "full" approach more, it feels like it could be, at least in theory, optimized somewhat.
-Recall that in this approach we have a graph of function instantiations, which starts at the root (`main`), and contains various monomorphisations of `guinea_pig` on paths reachable from the root.
+Recall that in this approach we have a graph of function instantiations, which starts at the root (`main`), and contains various monomorphizations of `guinea_pig` on paths reachable from the root.
 
 It is clear we actually don't need the full graph to answer queries about instantiations of `guinea_pig`.
 For example, if we have something like
@@ -150,10 +150,10 @@ fn helper() i32 {
 
 and the `helper` does not (transitively) call `guinea_pig`, we can avoid looking into its body, as the signature is enough to analyze everything else.
 
-More precisely, given the graph of monomorphisations, we can select minimal subgraph which includes all paths from `main` to `guinea_pig` instantiations, as well as all the functions whose bodies we need to process to understand their signatures.
+More precisely, given the graph of monomorphizations, we can select minimal subgraph which includes all paths from `main` to `guinea_pig` instantiations, as well as all the functions whose bodies we need to process to understand their signatures.
 My intuition is that the size of that subgraph is going to be much smaller than the whole thing, and, in principle, an algorithm which would analyze only that subgraph should be speedy enough in practice.
 
-The problem though is that, as far as I know, it's not possible to understand what belongs to the subgraph without analysing the whole thing!
+The problem though is that, as far as I know, it's not possible to understand what belongs to the subgraph without analyzing the whole thing!
 In particular, using compile-time reflection our `guinea_pig` can be called through something like `comptime "guinea" ++ "_pig"`.
 It's impossible to infer the call graph just from Zir.
 
@@ -176,7 +176,7 @@ fn guinea_pig(comptime T: type, foo: Foo) void {
 
 from a different direction.
 What if we just treat this function as the root of our graph?
-We can'd do that exactly, because it has some comptime parameters.
+We can't do that exactly, because it has some comptime parameters.
 But we _can_ say that we have some opaque values for the parameters: `T = opaquevalue`.
 Of course, we won't be able to fully evaluate everything and things like `if (T == int)` would probably need to propagate opaqueness.
 At the same time, something like the result of `BoundedArray(opaque)` would still be pretty useful for an IDE.
@@ -200,7 +200,7 @@ Given the unused function problem, I think it's impossible to avoid at least som
 
 With abstract interpretation machinery in place, it can be used as a first, responsive layer of IDE support.
 
-Computing the full set of monomoprisations in background can be used to augment these limited synchronous features with precise results asynchronously.
+Computing the full set of monomorphizations in the background can be used to augment these limited synchronous features with precise results asynchronously.
 Though, this might be tough to express in existing editor UIs.
 Eg, the goto definition result is now an asynchronous stream of values.
 

--- a/content/posts/2023-02-12-a-love-letter-to-deno.dj
+++ b/content/posts/2023-02-12-a-love-letter-to-deno.dj
@@ -1,13 +1,13 @@
 # <3 Deno
 
 [Deno](https://deno.land/manual@v1.30.3/introduction) is a relatively new JavaScript runtime.
-I find quite interesting and aesthetically appealing, in-line with the recent trend to rein in the worse-is-better law of software evolution.
+I find it quite interesting and aesthetically appealing, in-line with the recent trend to rein in the worse-is-better law of software evolution.
 This post explains why.
 
 The way I see it, the primary goal of Deno is to simplify development of software, relative to the status quo.
 Simplifying means removing the accidental complexity.
 To me, a big source of accidental complexity in today's software are implicit dependencies.
-Software is built of many components, and while some components are relatively well-defined (Linux syscall interface, amd64 ISA), others are much less so.
+Software is built out of many components, and while some components are relatively well-defined (Linux syscall interface, amd64 ISA), others are much less so.
 Example: upgrading OpenSSL for your Rust project from 1.1.1 to 3.0.0 works on your machine, but breaks on CI, because 3.0.0 now needs some new perl module, which is _expected_ to usually be there together with the perl installation, but that is not universally so.
 One way to solve these kinds of problems is by putting {-an abstraction boundary-} a docker container around them.
 But a different approach is to very carefully avoid creating the issues.
@@ -39,7 +39,7 @@ Similarly, Deno is a TypeScript runtime --- there's no transpilation step involv
 Deno does not rely on system's shell.
 Most scripting environments, including node, python, and ruby, make a grave mistake of adding an API to spawn a process intermediated by the shell.
 This is slow, insecure, and brittle (_which_ shell was that, again?).
-I have a  [longer post](https://matklad.github.io/2021/07/30/shell-injection.html) about the issue.
+I have a [longer post](https://matklad.github.io/2021/07/30/shell-injection.html) about the issue.
 Deno doesn't have this vulnerable API.
 Not that "not having an API" is a particularly challenging technical achievement, but it _is_ better than the current default.
 

--- a/content/posts/2023-02-16-three-state-stability.dj
+++ b/content/posts/2023-02-16-three-state-stability.dj
@@ -1,8 +1,8 @@
 # Three-State Stability
 
-Usually, when discussing stability of the APIs (in a broad sense; databases and programming languages are also APIs), only two states are mentioned:
+Usually, when discussing stability of APIs (in a broad sense; databases and programming languages are also APIs), only two states are mentioned:
 
-- an API is stable if there's a promise that all future changes would be backwards compatible
+- an API is stable if there's a promise that all future changes will be backwards compatible
 - otherwise, it is unstable
 
 This is reflected in, e.g, SemVer: before 1.0, anything goes, after 1.0 you only allow to break API if you bump major version.
@@ -12,7 +12,7 @@ In addition to clearly stable or clearly unstable, there's often a poorly define
 It often manifests as either:
 
 - some technically non-stable version of the project (e.g., `0.2`) becoming widely used and de facto stable
-- some minor but technically breaking quietly slipping in shortly after 1.0
+- some minor but technically breaking change quietly slipping in shortly after 1.0
 
 Here's what I think happens over a lifetime of a typical API:
 

--- a/content/posts/2023-02-21-why-SAT-is-hard.dj
+++ b/content/posts/2023-02-21-why-SAT-is-hard.dj
@@ -84,7 +84,7 @@ First, let's define a (somewhat artificial) problem which is trivially NP-comple
 Let's start with this one: "Given a Turing machine and an input for it of length N, will the machine output {"yes"} after N^k^ steps?"
 (here k is a fixed parameter; pedantically, I describe a family of problems, one for each k)
 
-This is _very_ similar to a halting problem, but also much easier.
+This is _very_ similar to the halting problem, but also much easier.
 We explicitly bound the runtime of the Turing machine by a polynomial, so we don't need to worry about "looping forever" case --- that would be a "no" for us.
 The naive algorithm here works: we just run the given machine on a given input for a given amount of steps and look at the answer.
 
@@ -103,12 +103,12 @@ This is because SAT is powerful enough to encode a Turing machine!
 _First_, note that we can encode a state of a Turing machine as a set of boolean variables.
 We'll need a boolean variable T~i~ for each position on a tape.
 The tape is in general infinite, but all our Turing machines run for polynomial (finite) time, so they use only a finite amount of cells, and it's enough to create variables only for those cells.
-Position of the head can also be described by a set of booleans variables.
+Position of the head can also be described by a set of boolean variables.
 For example, we can have a P~i~ "is the head at a cell `i`" variable for each cell.
 Similarly, we can encode the finite number of states our machine can be in as a set of S~i~ variables (is the machine in state `i`?).
 
 _Second_, we can write a set of boolean equations which describe a single transition of our Turing machine.
-For example  the value of cell i at the second step T2~i~ will depend on its value on the previous step T1~i~, whether the head was at `i` (P1~i~) and the rules of our specific states.
+For example, the value of cell i at the second step T2~i~ will depend on its value on the previous step T1~i~, whether the head was at `i` (P1~i~) and the rules of our specific states.
 For example, if our machine flips bits in state `0` and keeps them in state `1`, then the formula we get for each cell is
 
 ```


### PR DESCRIPTION
Fixes for typos, grammar, and code examples.

Split up to be more manageable.