### PR TITLE
Changes for 2023 Posts (2/5)

### DIFF
--- a/content/posts/2023-03-26-zig-and-rust.dj
+++ b/content/posts/2023-03-26-zig-and-rust.dj
@@ -59,7 +59,7 @@ TigerBeetle is the opposite of that.
 It is a database, with domain model fixed at compile time (we currently do double-entry bookkeeping).
 The database is distributed, meaning that there are six TigerBeetle replicas running on different geographically and operationally isolated machines, which together implement a replicated state machine.
 That is, TigerBeetle replicas exchange messages to make sure every replica processes the same set of transactions, in the same order.
-That's a surprisingly hard problem if you allow machines to fail (the whole point of using many machines for redundancy), so we use a smart [consensus algorithm](http://pmg.csail.mit.edu/papers/vr-revisited.pdf)  (non-byzantine) for this.
+That's a surprisingly hard problem if you allow machines to fail (the whole point of using many machines for redundancy), so we use a smart [consensus algorithm](http://pmg.csail.mit.edu/papers/vr-revisited.pdf) (non-byzantine) for this.
 Traditionally, consensus algorithms assume reliable storage --- data once written to disk can be always retrieved later.
 In reality, storage is unreliable, nearly byzantine --- a disk can return bogus data without signaling an error, and even a single such error can [break consensus](https://www.usenix.org/conference/fast18/presentation/alagappan).
 TigerBeetle combats that by allowing a replica to repair its local storage using data from other replicas.
@@ -70,7 +70,7 @@ Rather than reining in sources of non-determinism, we build the whole system fro
 Here are some of our unconventional choices ([design doc](https://github.com/tigerbeetledb/tigerbeetle/blob/fe09404d465df46b2bdfc017633eff37b4ab2343/docs/DESIGN.md)):
 
 It's [hard mode](https://matklad.github.io/2022/10/06/hard-mode-rust.html)!
-We allocate all the memory at a startup, and there's zero allocation after that.
+We allocate all the memory at startup, and there's zero allocation after that.
 This removes all the uncertainty about allocation.
 
 The code is architected with brutal simplicity.
@@ -145,7 +145,7 @@ I noticed that a lot of Zig code written in "let's replace [RAII](https://doc.ru
 
 But it often is possible to architect the software such that there's little resource management to do (eg, allocating everything up-front, like TigerBeetle, or even at compile time, like many smaller embedded systems).
 It's hard --- simplicity is always hard.
-But, if you go this  way, I feel like Zig can provide substantial benefits.
+But, if you go this way, I feel like Zig can provide substantial benefits.
 
 Zig has just a single feature, dynamically-typed comptime, which subsumes most of the special-cased Rust machinery.
 It is definitely a tradeoff, instantiation-time errors are much worse for complex cases.
@@ -164,10 +164,10 @@ I don't think any popular Rust frameworks do this --- using the global allocator
 Zig forces you to pass the allocator in, so you might as well think about the most appropriate one!
 
 Similarly, the standard library is very conscious about allocation, more so than Rust's.
-Collections are _not_ parametrized by an allocator, like in C++ or (future) Rust.
+Collections are _not_ parameterized by an allocator, like in C++ or (future) Rust.
 Rather, an allocator is passed in explicitly to every method which actually needs to allocate.
 This is [_Call Site Dependency Injection_](https://matklad.github.io/2020/12/28/csdi.html), and it is more flexible.
-For example in TigerBeetle we need a couple of hash maps.
+For example, in TigerBeetle we need a couple of hash maps.
 These maps are sized at a startup time to hold just the right number of elements, and are never resized.
 So we pass an allocator to [`init`](https://github.com/tigerbeetledb/tigerbeetle/blob/53092098d69cc8facf94a2472bc79ca9d525a605/src/vsr/replica.zig#L540) method, but we don't pass it to the [event loop](https://github.com/tigerbeetledb/tigerbeetle/blob/53092098d69cc8facf94a2472bc79ca9d525a605/src/vsr/replica.zig#L758).
 We get to both use the standard hash-map, and to feel confident that there's no way we can allocate in the actual event loop, because it doesn't have access to an allocator.
@@ -202,7 +202,7 @@ But, with the lazy compilation model and the absence of out-of-the-language meta
 To position itself well for the future in terms of IDE support, I think it would be nice if the compiler gets the basic data model for IDE use-case.
 That is, there should be an API to create a persistent analyzer process, which ingests a stream of code edits, and produces a continuously updated model of the code without explicit compilation requests.
 The model can be very simple, just "give me an AST of this file at this point in time" would do --- all the fancy IDE features can be filled in later.
-What matters is a shape of data flow through the compiler --- not an edit-compile cycle, but rather a continuously updated view of the world.
+What matters is the shape of data flow through the compiler --- not an edit-compile cycle, but rather a continuously updated view of the world.
 
 _Fourth_, one of the values of Zig which resonates with me a lot is a preference for low-dependency, self-contained processes.
 Ideally, you get yourself a `./zig` binary, and go from there.

--- a/content/posts/2023-03-28-rust-is-a-scalable-language.dj
+++ b/content/posts/2023-03-28-rust-is-a-scalable-language.dj
@@ -13,7 +13,7 @@ And you would only need Rust --- while it excels in the lowest half of the stack
 
 Rust is horizontally scalable, in that you can easily parallelize development of large software artifacts across many people and teams.
 Rust itself moves with a breakneck speed, which is surprising for such a loosely coordinated and chronically understaffed open source project of this scale.
-The relatively small community  managed to put together a comprehensive ecosystem of composable high-quality crates on a short notice.
+The relatively small community managed to put together a comprehensive ecosystem of composable high-quality crates on a short notice.
 Rust is so easy to compose reliably that even the stdlib itself does not shy from pulling dependencies from crates.io.
 
 Steve Klabnik wrote about [_Rust's Golden Rule_](https://steveklabnik.com/writing/rusts-golden-rule),

--- a/content/posts/2023-04-09-can-you-trust-a-compiler-to-optimize-your-code.dj
+++ b/content/posts/2023-04-09-can-you-trust-a-compiler-to-optimize-your-code.dj
@@ -229,7 +229,7 @@ fn call2(f: fn()) {
 
 So, the first rule is to make most of the calls statically resolvable, to allow inlining.
 Function pointers and dynamic dispatch prevent inlining.
-Separate compilation might also get in a way of inlining, see this [separate essay](https://matklad.github.io/2021/07/09/inline-in-rust.html) on the topic.
+Separate compilation might also get in the way of inlining, see this [separate essay](https://matklad.github.io/2021/07/09/inline-in-rust.html) on the topic.
 
 Similarly, indirection in _memory_ can cause troubles for the compiler.
 
@@ -293,7 +293,7 @@ Make sure that most calls are known at compile time and can be inlined, trust th
 Let's apply this general framework of giving a compiler optimizable code to work with to auto-vectorization.
 We will be optimizing the function which computes the longest common prefix between two slices of bytes (thanks [@nkkarpov](https://github.com/nkkarpov) for the example).
 
-A  direct implementation would look like this:
+A direct implementation would look like this:
 
 ```rust
 use std::iter::zip;

--- a/content/posts/2023-04-13-reasonable-bootstrap.dj
+++ b/content/posts/2023-04-13-reasonable-bootstrap.dj
@@ -53,7 +53,7 @@ Specific properties we use for this setup:
 
 This setup does not prevent the trusting trust attack.
 However, it is possible to rebuild the bootstrap seed using a different compiler.
-Using that compiler to compiler rustc to .wasm will produce a different blob.
+Using that compiler to compile rustc to .wasm will produce a different blob.
 But using that .wasm to recompile rustc again should produce the blob from the seed (unless, of course, there's a trojan in the seed).
 
 This setup does not minimize the size of opaque binary blobs in the seed.


### PR DESCRIPTION
Fixes for typos, grammar, and code examples.

Split up to be more manageable.